### PR TITLE
feat: updated deploy script in able to deploy chf:usdc fxpool to kovan

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@balancer-labs/v2-deployments": "^1.1.1",
-    "@halodao/xave-contract-addresses": "^0.0.6",
+    "@halodao/xave-contract-addresses": "^0.0.7",
     "@tenderly/hardhat-tenderly": "^1.0.12",
     "@types/chai": "^4.2.22",
     "@types/chai-almost": "^1.0.1",

--- a/scripts/cli/addLiquidityCLI.ts
+++ b/scripts/cli/addLiquidityCLI.ts
@@ -53,12 +53,16 @@ inquirer
     const vaultAddress = '0xBA12222222228d8Ba445958a75a0704d566BF2C8'
 
     // fxPHP:USDC
-    const poolId = '0x5d5aabcac8aa7288895912588a7b8787ab1fba220002000000000000000008ee'
-    const baseTokenAddress = '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0'
+    // const poolId = '0x5d5aabcac8aa7288895912588a7b8787ab1fba220002000000000000000008ee'
+    // const baseTokenAddress = '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0'
 
     // EURS:USDC
     // const poolId = '0x4b7315e3336153d54392dcb3f49800594362597b0002000000000000000008f0'
     // const baseTokenAddress = '0xaA64D57E3c781bcFB2e8B1e1C9936C302Db84bCE'
+
+    // CHF:USDC
+    const poolId = '0xaa33da6719a7f9181beeb20a27f4464df461e7e400020000000000000000096d'
+    const baseTokenAddress = '0xE9958574866587c391735b7e7CE0D79432d3b9d0'
 
     const quoteTokenAddress = '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE'
     const frominternalbalance = false

--- a/scripts/cli/deployFxPoolCLI.ts
+++ b/scripts/cli/deployFxPoolCLI.ts
@@ -4,7 +4,7 @@ const haloContractAddresses = require('@halodao/xave-contract-addresses')
 
 const runNpmCommand = (command: string) => childProcess.execSync(command, { stdio: [0, 1, 2] })
 
-const baseTokens = ['fxPHP', 'XSGD', 'EURS']
+const baseTokens = ['fxPHP', 'XSGD', 'EURS', 'CHF']
 
 inquirer
   .prompt([

--- a/scripts/pool-actions/deployFxPool.ts
+++ b/scripts/pool-actions/deployFxPool.ts
@@ -15,9 +15,9 @@ declare const ethers: any
 
 export default async (taskArgs: any) => {
   const ALPHA = ethers.utils.parseUnits('0.8')
-  const BETA = ethers.utils.parseUnits('0.5')
-  const MAX = ethers.utils.parseUnits('0.15')
-  const EPSILON = ethers.utils.parseUnits('0.0004')
+  const BETA = ethers.utils.parseUnits('0.48')
+  const MAX = ethers.utils.parseUnits('0.175')
+  const EPSILON = ethers.utils.parseUnits('0.0005')
   const LAMBDA = ethers.utils.parseUnits('0.3')
 
   const network = taskArgs.to
@@ -177,17 +177,15 @@ export default async (taskArgs: any) => {
     unitSeconds: ethers.utils.parseUnits('100'),
     vault: vaultAddress,
     percentFee: ethers.utils.parseUnits('0.01'),
-    name: `HALO ${baseToken}USDC FXPool`,
-    symbol: `HFX-${baseToken}USDC`,
+    name: `XAVE ${baseToken}USDC FXPool`,
+    symbol: `FX-${baseToken}USDC`,
   })
   const fxPool: FXPool = await FXPoolFactory.deploy(
     sortedAssets,
-    deadline,
-    ethers.utils.parseUnits('100'),
     vaultAddress,
     ethers.utils.parseUnits('0.01'),
-    `HALO ${baseToken}USDC FXPool`,
-    `HFX-${baseToken}USDC`
+    `XAVE ${baseToken}USDC FXPool`,
+    `FX-${baseToken}USDC`
   )
   await fxPool.deployed()
   console.log(`> FxPool successfully deployed at: ${fxPool.address}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,10 +748,10 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@halodao/xave-contract-addresses@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@halodao/xave-contract-addresses/-/xave-contract-addresses-0.0.6.tgz#8d4539a669237bfe6f277494ad13fb1d21ae990a"
-  integrity sha512-mthirhhOvZK93jPF1iY4LH/XVSzhRDoq41PPAwxxnsXeZMbZHJg0+PvS7t9m937LEQ56IH/kLxFRge32X5NuxQ==
+"@halodao/xave-contract-addresses@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@halodao/xave-contract-addresses/-/xave-contract-addresses-0.0.7.tgz#fe1bbd6f1f687e17b2dda8a5ff41c905b2a269c5"
+  integrity sha512-jPskSjhVqVB/NnhupYbr6hyhZXnXU/5Rtg7jAaHDYi9ZGv13Vypu/gTriGOQkeMP+rNtHYlSaXQ2RDuVn9WSwg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
Quick changes in able to deploy CHF:USDC FXPool on kovan
- updated xave-contract-addresses version (contains CHF oracle)
- updated FxPool deploy script
  - modify curve params to match the same CHF:USDC curve we just deployed on amm-v1
  - `FxPool.deploy()` parameters decreased from 7 to 5
